### PR TITLE
Enable/disable busy LED and save for power cycle

### DIFF
--- a/QuokkADB.md
+++ b/QuokkADB.md
@@ -24,6 +24,11 @@ The stack port carries all four ADB signals.
 
 ![QuokkADB picture](images/quokkadb.jpg)
 
+## Special Key-combos
+The special keyboad commands start with `CTRL + SHIFT + CAPLOCK` and a letter key.  Example: `CTRL + SHIFT + CAPLOCK + V` ghost types the firmware version.
+ - `V` - Ghost types firmware version
+ - `L` - Ghost types the busy LED status (ON/OFF) and saves the new status to flash and will be used when the board powers on again. This controls
+ whether the LED blinks when accessing the ADB bus or remains off for light sensitive situations.
 
 ## Programming 
 The firmware version can be found by opening up a empty text document or program that allows typing. 
@@ -53,8 +58,7 @@ disconnected).
  - Rear facing and front facing ADB can be connected to host (Mac)
  or used to connected to another ADB device
  - Mouse and keyboard readdressing implemented so multiple QuokkADBs, other ADB keyboards, and/or mice can be used 
- - Multiple USB keyboards or mice can be attached and will work. Known issue: Caps lock led is limited to changing on the keyboard which it was pressed.
- - Limitations with USB Host support in TinyUSB mean only one level of USB hubs may be attached and some USB composite keyboard have been found not to work.
+ - Multiple USB keyboards or mice can be attached and will work.
 
 ## Parity with USB Wombat
  - Context menu for Mac OS 8.1 and above - middle mouse button switches right click mode

--- a/src/firmware/include/quokkadb_tusb_config.h
+++ b/src/firmware/include/quokkadb_tusb_config.h
@@ -41,7 +41,7 @@
 //--------------------------------------------------------------------
 // COMMON CONFIGURATION
 //--------------------------------------------------------------------
-// #define CFG_TUSB_DEBUG 3
+
 #define CFG_TUSB_OS               OPT_OS_PICO
 #define CFG_TUSB_MCU              OPT_MCU_RP2040 
 
@@ -49,7 +49,9 @@
 #define CFG_TUH_ENABLED     1
 
 // CFG_TUSB_DEBUG is defined by compiler in DEBUG build
-// #define CFG_TUSB_DEBUG           0
+#define CFG_TUSB_DEBUG           0
+//#define CFG_TUSB_DEBUG 3
+
 #undef PICO_DEFAULT_UART
 #undef PICO_DEFAULT_UART_TX_PIN
 #undef PICO_DEFAULT_UART_RX_PIN
@@ -78,11 +80,11 @@
 //--------------------------------------------------------------------
 
 // Size of buffer to hold descriptors and other data used for enumeration
-#define CFG_TUH_ENUMERATION_BUFSIZE 256
+#define CFG_TUH_ENUMERATION_BUFSIZE 512
 
-#define CFG_TUH_HUB                 1
+#define CFG_TUH_HUB                 4
 // max device support (excluding hub device)
-#define CFG_TUH_DEVICE_MAX          (CFG_TUH_HUB ? 4 : 1) // hub typically has 4 ports
+#define CFG_TUH_DEVICE_MAX          16 // hub typically has 4 ports
 #define CFG_TUH_HID                 4 // typical keyboard + mouse device can have 3-4 HID interfaces
 #define CFG_TUH_MSC                 0
 

--- a/src/firmware/lib/QuokkADB/include/flashsettings.h
+++ b/src/firmware/lib/QuokkADB/include/flashsettings.h
@@ -1,0 +1,53 @@
+//---------------------------------------------------------------------------
+//
+//	QuokkADB ADB keyboard and mouse adapter
+//
+//     Copyright (C) 2022 Rabbit Hole Computing LLC
+//
+//  This file is part of QuokkADB.
+//
+//  This file is free software: you can redistribute it and/or modify it under 
+//  the terms of the GNU General Public License as published by the Free 
+//  Software Foundation, either version 3 of the License, or (at your option) 
+// any later version.
+//
+//  This file is distributed in the hope that it will be useful, but WITHOUT ANY 
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
+//  FOR A PARTICULAR PURPOSE. See the GNU General Public License for more 
+//  details.
+//
+//  You should have received a copy of the GNU General Public License along 
+//  with this file. If not, see <https://www.gnu.org/licenses/>.
+//
+//  Portions of this code were originally released under a Modified BSD 
+//  License. See LICENSE in the root of this repository for more info.
+//
+//----------------------------------------------------------------------------
+#pragma once
+#include <stdint.h>
+#include <hardware/flash.h>
+
+#define QUOKKADB_SETTINGS_MAGIC_NUMBER 0x71DE
+
+struct __attribute((packed)) QuokkADBSettings 
+{
+    uint16_t magic_number;
+    uint8_t led_on: 1;
+    uint8_t reserved_bits: 7;
+    uint8_t reserved_bytes[253];
+};
+
+class FlashSettings
+{
+public:
+    void init(void);
+    void write_settings_page(uint8_t *buf); 
+    uint8_t* read_settings_page(void);
+    void save(void);
+    inline QuokkADBSettings* settings() {return &_settings;}
+private:
+    uint32_t _capacity = 0;
+    uint32_t _last_sector = 0;
+    QuokkADBSettings _settings;
+};
+

--- a/src/firmware/lib/QuokkADB/include/quokkadb_config.h
+++ b/src/firmware/lib/QuokkADB/include/quokkadb_config.h
@@ -22,10 +22,12 @@
 //  with the file. If not, see <https://www.gnu.org/licenses/>.
 //
 //---------------------------------------------------------------------------
+#pragma once
 
-// Use variables for version number
-#define FW_VER_NUM      "0.1.1"
+// Use macros for version number
+#define FW_VER_NUM      "0.1.2"
 #define FW_VER_SUFFIX   "beta"
 #define QUOKKADB_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 #define PRODUCT_NAME "QuokkADB"
 #define QUOKKADB_FW_VER_STRING PRODUCT_NAME " firmware: " QUOKKADB_FW_VERSION
+

--- a/src/firmware/lib/QuokkADB/src/flashsettings.cpp
+++ b/src/firmware/lib/QuokkADB/src/flashsettings.cpp
@@ -1,0 +1,53 @@
+#include "flashsettings.h"
+#include "pico/multicore.h"
+#include "string.h"
+#define STORAGE_CMD_TOTAL_BYTES 64
+
+void FlashSettings::init(void)
+{
+    // Get Flash info
+    uint8_t txbuf[STORAGE_CMD_TOTAL_BYTES] = {0x9f};
+    uint8_t rxbuf[STORAGE_CMD_TOTAL_BYTES] = {0};
+    uint32_t saved_isr_state = save_and_disable_interrupts();
+    flash_do_cmd(txbuf, rxbuf, STORAGE_CMD_TOTAL_BYTES);
+    restore_interrupts(saved_isr_state);
+    _capacity =  1 << rxbuf[3];
+    _last_sector = _capacity - FLASH_SECTOR_SIZE;
+
+    // Read initial settings
+    uint8_t* setting_buffer = read_settings_page();
+    
+    if (((uint16_t*)setting_buffer)[0] == QUOKKADB_SETTINGS_MAGIC_NUMBER) 
+    {
+        memcpy((void*)&_settings, setting_buffer, FLASH_PAGE_SIZE);
+    }
+    else
+    {
+        // set default values
+        _settings.magic_number = QUOKKADB_SETTINGS_MAGIC_NUMBER;
+        _settings.led_on = 1;
+    }
+
+}
+
+void FlashSettings::write_settings_page(uint8_t *buf)
+{
+    multicore_lockout_start_blocking();
+    uint32_t saved_isr_state = save_and_disable_interrupts();
+
+    flash_range_erase(_last_sector, FLASH_SECTOR_SIZE);
+    flash_range_program(_last_sector, buf, FLASH_PAGE_SIZE);
+
+    restore_interrupts(saved_isr_state);
+    multicore_lockout_end_blocking();
+}
+
+uint8_t* FlashSettings::read_settings_page(void)
+{
+    return (uint8_t*)(XIP_BASE + _last_sector);
+}
+
+void FlashSettings::save(void)
+{
+    write_settings_page((uint8_t*)&_settings);
+}

--- a/src/firmware/lib/QuokkADB/src/keyboardrptparser.cpp
+++ b/src/firmware/lib/QuokkADB/src/keyboardrptparser.cpp
@@ -29,6 +29,7 @@
 #include "usb_hid_keys.h"
 #include "quokkadb_config.h"
 #include "char2usbkeycode.h"
+#include "flashsettings.h"
 #include <tusb.h>
 
 #define VALUE_WITHIN(v,l,h) (((v)>=(l)) && ((v)<=(h)))
@@ -36,6 +37,7 @@
 
 extern uint16_t modifierkeys;
 extern bool set_hid_report_ready;
+extern FlashSettings setting_storage;
 
 uint8_t inline findModifierKey(hid_keyboard_report_t const *report, const hid_keyboard_modifier_bm_t mod ) {
         return (mod & report->modifier) ? 1 : 0;
@@ -154,10 +156,10 @@ void KeyboardReportParser::SetUSBkeyboardLEDs(bool capslock, bool numlock, bool 
 bool KeyboardReportParser::SpecialKeyCombo(KBDINFO *cur_kbd_info)
 {
         uint8_t keys_down[6] = {};
-                // Special keycombo actions
+        // Special keycombo actions
         uint8_t special_key_count = 0;
         uint8_t special_key = 0;
-        uint8_t special_keys[] = { USB_KEY_V, USB_KEY_I};
+        uint8_t special_keys[] = { USB_KEY_V, USB_KEY_L};
         uint8_t caps_lock_down = false;
         
         for (uint8_t i = 0; i < 6; i++)
@@ -187,6 +189,18 @@ bool KeyboardReportParser::SpecialKeyCombo(KBDINFO *cur_kbd_info)
                 {
                 case USB_KEY_V:
                         SendString(QUOKKADB_FW_VER_STRING);
+                break;
+                case USB_KEY_L:
+                        setting_storage.settings()->led_on = ~setting_storage.settings()->led_on;
+                        setting_storage.save();
+                        if (setting_storage.settings()->led_on) 
+                        {
+                                SendString("Busy LED is on");
+                        }   
+                        else
+                        {
+                                SendString("Busy LED is off");
+                        }                 
                 break;        
                 }
                 

--- a/src/firmware/platformio.ini
+++ b/src/firmware/platformio.ini
@@ -44,5 +44,5 @@ build_flags =
     -D QUOKKADB
     -D SCQ_RP2040_MUTEX
     -D PRINTF_ALIAS_STANDARD_FUNCTION_NAMES=1
-debug_build_flags = -Wall -Os -ggdb -g3 -DLOG=2 
+debug_build_flags = -Wall -Os -ggdb -g3 
 ;monitor_port = SELECT SERIAL PORT


### PR DESCRIPTION
Add the ability to turn on or off the busy LED blinking. Save the setting to flash and use it when the board is powered on again.