### PR TITLE
QuokkADB switching from PlatformIO to Cmake

### DIFF
--- a/src/firmware/CMakeLists.txt
+++ b/src/firmware/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.24)
 
 set(PICO_BOARD_HEADER_DIRS ${CMAKE_SOURCE_DIR}/boards) 
 # initialize the SDK based on PICO_SDK_PATH

--- a/src/firmware/CMakeLists.txt
+++ b/src/firmware/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.25)
+
+set(PICO_BOARD_HEADER_DIRS ${CMAKE_SOURCE_DIR}/boards) 
+# initialize the SDK based on PICO_SDK_PATH
+# note: this must happen before project()
+include(pico_sdk_import.cmake)
+
+project(QuokkADB-firmware)
+
+# initialize the Raspberry Pi Pico SDK
+pico_sdk_init()
+
+# rest of your project
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Os -DQUOKKADB -DSCQ_RP2040_MUTEX -DPICO_BOARD=quokkadb")
+target_include_directories(tinyusb_common INTERFACE include)
+
+# add_executable(QuokkADB src/main.cpp)
+add_subdirectory(src)
+add_subdirectory(lib/adb/src)
+add_subdirectory(lib/QuokkADB/src)
+add_subdirectory(lib/usb/src)
+
+#target_link_libraries(QuokkADB-firmware PUBLIC QuokkADB adb usb pico_stdlib pico_multicore hardware_flash)
+
+#target_link_libraries(QuokkADB PUBLIC ${EXTRA_LIBS})
+#target_include_directories(QuokkADB PUBLIC
+#                            "${PROJECT_BINARY_DIR}"
+#                             ${EXTRA_LIBS}
+#                          )

--- a/src/firmware/boards/quokkadb.h
+++ b/src/firmware/boards/quokkadb.h
@@ -9,7 +9,7 @@
 //  This file is free software: you can redistribute it and/or modify it under 
 //  the terms of the GNU General Public License as published by the Free 
 //  Software Foundation, either version 3 of the License, or (at your option) 
-//  any later version.
+// any later version.
 //
 //  This file is distributed in the hope that it will be useful, but WITHOUT ANY 
 //  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
@@ -25,58 +25,38 @@
 //----------------------------------------------------------------------------
 
 
-#include "quokkadb_gpio.h"
-#include "pico/mutex.h"
-#include "hardware/gpio.h"
-#include <pico/printf.h>
+#ifndef _BOARDS_QUOKKADB_H
+#define _BOARDS_QUOKKADB_H
 
-mutex_t led_mutex;
+// For board detection
+#define QUOKKADB_BOARD
 
-
-
-extern bool global_debug;
-void adb_gpio_init(void) {
-    gpio_init(ADB_OUT_GPIO);
-    gpio_set_function(ADB_OUT_GPIO, GPIO_FUNC_SIO);
-    gpio_set_dir(ADB_OUT_GPIO, GPIO_OUT);
-    gpio_put(ADB_OUT_GPIO, true);
-
-    gpio_init(ADB_IN_GPIO);
-    gpio_set_dir(ADB_IN_GPIO, GPIO_IN);
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 16
+#endif
 
 
-}
+// --- FLASH ---
 
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
 
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
 
-void led_gpio_init(void) {
-    gpio_init(LED_GPIO);
-    gpio_set_function(LED_GPIO, GPIO_FUNC_SIO);
-    gpio_set_dir(LED_GPIO, GPIO_OUT);
-    LED_OFF();
-    mutex_init(&led_mutex);
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (2 * 1024 * 1024)
+#endif
 
-}
+// Drive high to force power supply into PWM mode (lower ripple on 3V3 at light loads)
+#define PICO_SMPS_MODE_PIN 23
 
-void uart_gpio_init(void) {
+#ifndef PICO_RP2040_B0_SUPPORTED
+#define PICO_RP2040_B0_SUPPORTED 1
+#endif
 
-    uart_init(UART_PORT, UART_TX_BAUD);
-    gpio_set_function(UART_TX_GPIO, GPIO_FUNC_UART);
-
-}
-    
-
-
-// Blink the led n times
-void led_blink(uint8_t times) {
-    mutex_enter_blocking(&led_mutex);
-    for (uint8_t i = 0; i < times; i++) {
-        LED_ON();
-        sleep_ms(75);
-        LED_OFF();
-        sleep_ms(75);
-    }
-    sleep_ms(75);    
-    mutex_exit(&led_mutex);
-}
-
+#endif

--- a/src/firmware/lib/QuokkADB/include/adb_platform.h
+++ b/src/firmware/lib/QuokkADB/include/adb_platform.h
@@ -27,6 +27,7 @@
 
 #include <stdint.h>
 #include "quokkadb_gpio.h"
+#include <hardware/timer.h>
 
 extern bool adb_collision;
 

--- a/src/firmware/lib/QuokkADB/include/keyboardrptparser.h
+++ b/src/firmware/lib/QuokkADB/include/keyboardrptparser.h
@@ -118,10 +118,8 @@ protected:
 
 public:
 
-        KeyboardReportParser() {
-                kbdLockingKeys.bLeds = 0;
-        };
-
+        KeyboardReportParser();
+        virtual ~KeyboardReportParser();
         void Parse(uint8_t dev_addr, uint8_t instance, hid_keyboard_report_t const *report);
         bool SpecialKeyCombo(KBDINFO *cur_kbd_info);
         void SendString(const char* message);
@@ -132,18 +130,16 @@ public:
         // Executes the LED changes from shared memory (meant to be run on the same core as tuh_task)
         void ChangeUSBKeyboardLEDs(void);
 
-        virtual bool PendingKeyboardEvent(void);
+        virtual bool PendingKeyboardEvent() = 0;
 
-        virtual void OnKeyDown(uint8_t mod __attribute__((unused)), uint8_t key __attribute__((unused))) {
-        };
+        virtual void OnKeyDown(uint8_t mod __attribute__((unused)), uint8_t key __attribute__((unused))) = 0;
 
-        virtual void OnKeyUp(uint8_t mod __attribute__((unused)), uint8_t key __attribute__((unused))) {
-        };
+        virtual void OnKeyUp(uint8_t mod __attribute__((unused)), uint8_t key __attribute__((unused))) = 0;
 
 
 protected:
 
-        virtual uint8_t HandleLockingKeys(uint8_t dev_addr, uint8_t instance, uint8_t key) {
+        uint8_t HandleLockingKeys(uint8_t dev_addr, uint8_t instance, uint8_t key) {
                 uint8_t old_keys = kbdLockingKeys.bLeds;
 
                 switch(key) {
@@ -168,24 +164,23 @@ protected:
                 return 0;
         };
 
-        virtual void OnModifierKeysChanged(uint8_t before __attribute__((unused)), uint8_t after __attribute__((unused))) {
-        };
+        virtual void OnModifierKeysChanged(uint8_t before __attribute__((unused)), uint8_t after __attribute__((unused))) = 0;
 
 
 
-        virtual const uint8_t *getNumKeys() {
+        const uint8_t *getNumKeys() {
                 return numKeys;
         };
 
-        virtual const uint8_t *getSymKeysUp() {
+        const uint8_t *getSymKeysUp() {
                 return symKeysUp;
         };
 
-        virtual const uint8_t *getSymKeysLo() {
+        const uint8_t *getSymKeysLo() {
                 return symKeysLo;
         };
 
-        virtual const uint8_t *getPadKeys() {
+        const uint8_t *getPadKeys() {
                 return padKeys;
         };
 };

--- a/src/firmware/lib/QuokkADB/src/CMakeLists.txt
+++ b/src/firmware/lib/QuokkADB/src/CMakeLists.txt
@@ -1,0 +1,15 @@
+
+add_library(QuokkADB 
+    adb_platform.cpp
+    char2usbkeycode.cpp
+    flashsettings.cpp
+    keyboardrptparser.cpp
+    mouserptparser.cpp
+    quokkadb_gpio.cpp
+    quokkadb.cpp
+    rp2040_serial.cpp
+    usbhost.cpp
+    )
+
+    target_link_libraries(QuokkADB pico_stdlib hardware_flash pico_multicore adb usb tinyusb_common tinyusb_host)
+    target_include_directories(QuokkADB PUBLIC ../include)

--- a/src/firmware/lib/QuokkADB/src/keyboardrptparser.cpp
+++ b/src/firmware/lib/QuokkADB/src/keyboardrptparser.cpp
@@ -42,6 +42,15 @@ extern FlashSettings setting_storage;
 uint8_t inline findModifierKey(hid_keyboard_report_t const *report, const hid_keyboard_modifier_bm_t mod ) {
         return (mod & report->modifier) ? 1 : 0;
 }
+
+KeyboardReportParser::KeyboardReportParser()
+{
+        kbdLockingKeys.bLeds = 0;
+}
+KeyboardReportParser::~KeyboardReportParser()
+{
+}
+
 void KeyboardReportParser::AddKeyboard(uint8_t dev_addr, uint8_t instance) {
         for(size_t i = 0; i < MAX_KEYBOARDS; i++)
         {

--- a/src/firmware/lib/QuokkADB/src/quokkadb.cpp
+++ b/src/firmware/lib/QuokkADB/src/quokkadb.cpp
@@ -39,7 +39,7 @@
 #include "pico/bootrom.h"
 
 #include "tusb.h"
-#include "printf/printf.h"
+#include <pico/printf.h>
 #include "rp2040_serial.h"
 #include "adb.h"
 #include "quokkadb_gpio.h"

--- a/src/firmware/lib/QuokkADB/src/rp2040_serial.cpp
+++ b/src/firmware/lib/QuokkADB/src/rp2040_serial.cpp
@@ -1,7 +1,7 @@
 // Minimal implementation of Arudino's Serial class
 #include "rp2040_serial.h"
 #include "quokkadb_gpio.h"
-#include "printf/printf.h"
+#include <pico/printf.h>
 
 namespace rp2040_serial {
  

--- a/src/firmware/lib/adb/include/adbkbdparser.h
+++ b/src/firmware/lib/adb/include/adbkbdparser.h
@@ -42,9 +42,9 @@ extern uint8_t usb_keycode_to_adb_code(uint8_t usb_code);
 class ADBKbdRptParser : public KbdRptParser
 {
 public:
-    ADBKbdRptParser();
-
     uint16_t GetAdbRegister0();
     uint16_t GetAdbRegister2();
+    ADBKbdRptParser();
+    virtual ~ADBKbdRptParser();
 
 };

--- a/src/firmware/lib/adb/src/CMakeLists.txt
+++ b/src/firmware/lib/adb/src/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+add_library(adb
+    adb.cpp
+    adbkbdparser.cpp
+    adbmouseparser.cpp
+    usbtoadb.cpp
+    )
+
+include_directories(../../misc/include)
+target_link_libraries(adb QuokkADB)
+target_include_directories(adb PUBLIC ../include)

--- a/src/firmware/lib/adb/src/adb.cpp
+++ b/src/firmware/lib/adb/src/adb.cpp
@@ -38,7 +38,7 @@
 #elif QUOKKADB
 #include <time.h>
 #include "rp2040_serial.h"
-#include "printf/printf.h"
+#include <pico/printf.h>
 using rp2040_serial::Serial;
 #endif
 
@@ -56,7 +56,7 @@ uint16_t kbdreg2 = 0xFFFF;
 uint8_t kbdsrq = 0;
 uint8_t mousesrq = 0;
 uint16_t modifierkeys = 0xFFFF;
-uint32_t kbskiptimer = 0;
+uint64_t kbskiptimer = 0;
 bool adb_reset = false;
 bool adb_collision = false; 
 bool collision_detection = false;
@@ -491,9 +491,12 @@ void AdbInterface::ProcessCommand(int16_t cmd)
           kbdreg0 = (kbdprev0 << 8) | 0xFF;
 
           // Save timestamp
-          kbskiptimer = millis();
+// @DEBUG switch back after getting cmake to compile QuokkADB
+//          kbskiptimer = millis();
+            kbskiptimer = (time_us_64() / 1000);
         }
-        else if (millis() - kbskiptimer < 90)
+//        else if (millis() - kbskiptimer < 90)
+        else if (time_us_64() / 1000 - kbskiptimer  < 90)
         {
           // Check timestamp and don't process the key event if it came right after a 255
           // This is meant to avoid a glitch where releasing a key sends 255->keydown instead

--- a/src/firmware/lib/adb/src/adbkbdparser.cpp
+++ b/src/firmware/lib/adb/src/adbkbdparser.cpp
@@ -38,6 +38,11 @@ ADBKbdRptParser::ADBKbdRptParser()
 {
 }
 
+ADBKbdRptParser::~ADBKbdRptParser()
+{
+
+}
+
 uint16_t ADBKbdRptParser::GetAdbRegister0()
 {
     KeyEvent *event;

--- a/src/firmware/lib/usb/include/usbkbdparser.h
+++ b/src/firmware/lib/usb/include/usbkbdparser.h
@@ -58,18 +58,18 @@ protected:
 class KbdRptParser : public KeyboardReportParser
 {
 public:
+    KbdRptParser();
+    virtual ~KbdRptParser();
     void PrintKey(uint8_t mod, uint8_t key);
-
     KeyEvent GetKeyEvent();
-    bool PendingKeyboardEvent();
+    bool PendingKeyboardEvent() override;
     void Reset(void);
     
 
 protected:
-    void OnModifierKeysChanged(uint8_t before, uint8_t after);
-
-    void OnKeyDown(uint8_t mod, uint8_t key);
-    void OnKeyUp(uint8_t mod, uint8_t key);
+    void OnModifierKeysChanged(uint8_t before, uint8_t after) override;
+    void OnKeyDown(uint8_t mod, uint8_t key) override;
+    void OnKeyUp(uint8_t mod, uint8_t key) override;
     void OnKeyPressed(uint8_t key);
 
     uint8_t m_last_key_pressed;

--- a/src/firmware/lib/usb/src/CMakeLists.txt
+++ b/src/firmware/lib/usb/src/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+add_library(usb
+    usbkbdparser.cpp
+    usbmouseparser.cpp
+    )
+
+    include_directories(../../misc/include)
+    target_link_libraries(usb QuokkADB)
+    target_include_directories(usb PUBLIC ../include)

--- a/src/firmware/lib/usb/src/usbkbdparser.cpp
+++ b/src/firmware/lib/usb/src/usbkbdparser.cpp
@@ -34,6 +34,12 @@ using rp2040_serial::Serial;
 
 extern bool global_debug;
 
+KbdRptParser::KbdRptParser()
+{
+}
+
+KbdRptParser::~KbdRptParser(){}
+
 bool KbdRptParser::PendingKeyboardEvent()
 {
     return !m_keyboard_events.isEmpty();

--- a/src/firmware/pico_sdk_import.cmake
+++ b/src/firmware/pico_sdk_import.cmake
@@ -1,0 +1,73 @@
+# This is a copy of <PICO_SDK_PATH>/external/pico_sdk_import.cmake
+
+# This can be dropped into an external project to help locate this SDK
+# It should be include()ed prior to project()
+
+if (DEFINED ENV{PICO_SDK_PATH} AND (NOT PICO_SDK_PATH))
+    set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
+    message("Using PICO_SDK_PATH from environment ('${PICO_SDK_PATH}')")
+endif ()
+
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT} AND (NOT PICO_SDK_FETCH_FROM_GIT))
+    set(PICO_SDK_FETCH_FROM_GIT $ENV{PICO_SDK_FETCH_FROM_GIT})
+    message("Using PICO_SDK_FETCH_FROM_GIT from environment ('${PICO_SDK_FETCH_FROM_GIT}')")
+endif ()
+
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_PATH} AND (NOT PICO_SDK_FETCH_FROM_GIT_PATH))
+    set(PICO_SDK_FETCH_FROM_GIT_PATH $ENV{PICO_SDK_FETCH_FROM_GIT_PATH})
+    message("Using PICO_SDK_FETCH_FROM_GIT_PATH from environment ('${PICO_SDK_FETCH_FROM_GIT_PATH}')")
+endif ()
+
+set(PICO_SDK_PATH "${PICO_SDK_PATH}" CACHE PATH "Path to the Raspberry Pi Pico SDK")
+set(PICO_SDK_FETCH_FROM_GIT "${PICO_SDK_FETCH_FROM_GIT}" CACHE BOOL "Set to ON to fetch copy of SDK from git if not otherwise locatable")
+set(PICO_SDK_FETCH_FROM_GIT_PATH "${PICO_SDK_FETCH_FROM_GIT_PATH}" CACHE FILEPATH "location to download SDK")
+
+if (NOT PICO_SDK_PATH)
+    if (PICO_SDK_FETCH_FROM_GIT)
+        include(FetchContent)
+        set(FETCHCONTENT_BASE_DIR_SAVE ${FETCHCONTENT_BASE_DIR})
+        if (PICO_SDK_FETCH_FROM_GIT_PATH)
+            get_filename_component(FETCHCONTENT_BASE_DIR "${PICO_SDK_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
+        endif ()
+        # GIT_SUBMODULES_RECURSE was added in 3.17
+        if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
+            FetchContent_Declare(
+                    pico_sdk
+                    GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                    GIT_TAG master
+                    GIT_SUBMODULES_RECURSE FALSE
+            )
+        else ()
+            FetchContent_Declare(
+                    pico_sdk
+                    GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                    GIT_TAG master
+            )
+        endif ()
+
+        if (NOT pico_sdk)
+            message("Downloading Raspberry Pi Pico SDK")
+            FetchContent_Populate(pico_sdk)
+            set(PICO_SDK_PATH ${pico_sdk_SOURCE_DIR})
+        endif ()
+        set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})
+    else ()
+        message(FATAL_ERROR
+                "SDK location was not specified. Please set PICO_SDK_PATH or set PICO_SDK_FETCH_FROM_GIT to on to fetch from git."
+                )
+    endif ()
+endif ()
+
+get_filename_component(PICO_SDK_PATH "${PICO_SDK_PATH}" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
+if (NOT EXISTS ${PICO_SDK_PATH})
+    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' not found")
+endif ()
+
+set(PICO_SDK_INIT_CMAKE_FILE ${PICO_SDK_PATH}/pico_sdk_init.cmake)
+if (NOT EXISTS ${PICO_SDK_INIT_CMAKE_FILE})
+    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' does not appear to contain the Raspberry Pi Pico SDK")
+endif ()
+
+set(PICO_SDK_PATH ${PICO_SDK_PATH} CACHE PATH "Path to the Raspberry Pi Pico SDK" FORCE)
+
+include(${PICO_SDK_INIT_CMAKE_FILE})

--- a/src/firmware/src/CMakeLists.txt
+++ b/src/firmware/src/CMakeLists.txt
@@ -1,0 +1,7 @@
+include_directories(${PROJECT_SOURCE_DIR}/include/)
+
+add_executable(QuokkADB-firmware main.cpp)
+
+target_link_libraries(QuokkADB-firmware QuokkADB)
+
+pico_add_extra_outputs(QuokkADB-firmware)


### PR DESCRIPTION
The platform wizio-pico for PlatformIO has discontinued development and as of this time the repo has been removed.  With the arrival of a new pico-sdk v1.5.0, CMake seems the best supported alternative to wizio-pico. 