### PR TITLE
Add the ability to extract the version number

### DIFF
--- a/QuokkADB.md
+++ b/QuokkADB.md
@@ -71,6 +71,7 @@ disconnected).
   
 ## QuokkADB LED blink meanings
  - On boot - one blink
+ - On second core and USB host driver loaded - one blink
  - On keyboard mount (connected to usb) - two blinks
  - On mouse mount (connected to usb)- three blinks
  - On device unmount (disconnected to usb) - one blink
@@ -81,6 +82,7 @@ If both a mouse and keyboard are connected to the QuokkADB:
 
 Turning on the Mac:
  1. One blink - power on
+ 2. One blink - second core and USB up and running
  2. Two blinks - keyboard initialized
  3. Three blinks - mouse initialized
 

--- a/src/firmware/lib/QuokkADB/include/platform_config.h
+++ b/src/firmware/lib/QuokkADB/include/platform_config.h
@@ -25,7 +25,7 @@
 #pragma once
 
 // Use macros for version number
-#define FW_VER_NUM      "0.2.3"
+#define FW_VER_NUM      "0.2.4"
 #define FW_VER_SUFFIX   "beta"
 #define PLATFORM_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX 
 #define PRODUCT_NAME "QuokkADB"

--- a/src/firmware/utils/rename_adbuino_binaries.sh
+++ b/src/firmware/utils/rename_adbuino_binaries.sh
@@ -30,11 +30,13 @@
 mkdir -p distrib
 
 DATE=$(date +%Y-%m-%d)
-VERSION=$(git describe --always)
+COMMIT=$(git describe --always)
+VERSION=$(gcc -E utils/version-extractor.cpp -Ilib/adbuino/include/ | grep  "version\[\]" | cut -d '"' -f2)
+SUFFIX=$(gcc -E utils/version-extractor.cpp -Ilib/adbuino/include/ | grep  "suffix\[\]" | cut -d '"' -f2)
 
 for file in $(ls .pio/build/adbuino/*.bin .pio/build/adbuino/*.elf .pio/build/adbuino/*.hex)
 do
-    NEWNAME=$(echo $file | sed 's|.pio/build/adbuino/\(.*\)\.\(.*\)|\1_'$DATE'_'$VERSION'.\2|')
+    NEWNAME=$(echo $file | sed 's|.pio/build/adbuino/\(.*\)\.\(.*\)|ADBuino-\1-v'$VERSION'-'$SUFFIX'_'$DATE'_'$COMMIT'.\2|')
     echo $file to distrib/$NEWNAME
     cp $file distrib/$NEWNAME
 done

--- a/src/firmware/utils/rename_quokkadb_binaries.sh
+++ b/src/firmware/utils/rename_quokkadb_binaries.sh
@@ -30,11 +30,13 @@
 mkdir -p distrib
 
 DATE=$(date +%Y-%m-%d)
-VERSION=$(git describe --always)
+COMMIT=$(git describe --always)
+VERSION=$(gcc -E utils/version-extractor.cpp -Ilib/QuokkADB/include/ | grep  "version\[\]" | cut -d '"' -f2)
+SUFFIX=$(gcc -E utils/version-extractor.cpp -Ilib/QuokkADB/include/ | grep  "suffix\[\]" | cut -d '"' -f2)
 
 for file in $(ls build/src/*.bin build/src/*.elf build/src/*.uf2)
 do
-    NEWNAME=$(echo $file | sed 's|build/src/\(.*\)\.\(.*\)|\1_'$DATE'_'$VERSION'.\2|')
+    NEWNAME=$(echo $file | sed 's|build/src/\(.*\)\.\(.*\)|\1-v'$VERSION'-'$SUFFIX'_'$DATE'_'$COMMIT'.\2|')
     echo $file to distrib/$NEWNAME
     cp $file distrib/$NEWNAME
 done

--- a/src/firmware/utils/version-extractor.cpp
+++ b/src/firmware/utils/version-extractor.cpp
@@ -1,0 +1,9 @@
+#include "platform_config.h"
+
+
+int main()
+{
+    char version[] = FW_VER_NUM;
+    char suffix[] = FW_VER_SUFFIX;
+    return 0;
+}


### PR DESCRIPTION
This is so GitHub workflows can automatically add the version string to the filename of the firmware. Also bumped version number for QuokkADB to the correct number.