### PR TITLE
Non blocking led, run from SRAM, update TinyUSB

### DIFF
--- a/src/firmware/lib/QuokkADB/include/blink.h
+++ b/src/firmware/lib/QuokkADB/include/blink.h
@@ -2,7 +2,7 @@
 //
 //	QuokkADB ADB keyboard and mouse adapter
 //
-//     Copyright (C) 2022 Rabbit Hole Computing LLC
+//     Copyright (C) 2023 Rabbit Hole Computing LLC
 //
 //  This file is part of QuokkADB.
 //
@@ -23,36 +23,27 @@
 //  License. See LICENSE in the root of this repository for more info.
 //
 //----------------------------------------------------------------------------
-
-
-
 #pragma once
-#include "stdlib.h"
-#include "hardware/structs/sio.h"
-#include "hardware/gpio.h"
-#include "hardware/uart.h"
 
+#include <scqueue.h>
+#define BLINK_QUEUE_LENGTH 5
 
-// Status LED GPIOs
-#define LED_GPIO     12
-#define LED_ON()    sio_hw->gpio_set = 1 << LED_GPIO
-#define LED_OFF()   sio_hw->gpio_clr = 1 << LED_GPIO
-#define LED_SET(x)  (x ? sio_hw->gpio_set = 1 << LED_GPIO : sio_hw->gpio_clr = 1 << LED_GPIO)
+struct blink_event_t
+{
+  uint8_t times;
+  uint32_t delay_ms;  
+};
 
-// ADB GPIOs
-#define ADB_IN_GPIO   19
-#define ADB_OUT_GPIO  18
-#define ADB_OUT_HIGH() sio_hw->gpio_set = 1 << ADB_OUT_GPIO
-#define ADB_OUT_LOW()  sio_hw->gpio_clr = 1 << ADB_OUT_GPIO
-#define ADB_IN_GET() (gpio_get(ADB_IN_GPIO))
+class BlinkLed
+{
+public:
+    bool blink(uint8_t times, uint32_t delay_ms = 75);
+    void led_on(bool force = false);
+    void led_off(bool force = false);
+    void poll();
+protected:
+    simple_circular_queue::SCQueue<blink_event_t*, BLINK_QUEUE_LENGTH> blink_queue;
+    bool blinking = false;
+};
 
-#define GPIO_TEST 20
-
-// UART out messaging
-#define UART_TX_GPIO    16
-#define UART_TX_BAUD    115200
-#define UART_PORT       uart0
-
-void adb_gpio_init(void);
-void uart_gpio_init(void);
-void led_gpio_init(void);
+extern BlinkLed blink_led;

--- a/src/firmware/lib/QuokkADB/include/blink.h
+++ b/src/firmware/lib/QuokkADB/include/blink.h
@@ -37,7 +37,7 @@ struct blink_event_t
 class BlinkLed
 {
 public:
-    bool blink(uint8_t times, uint32_t delay_ms = 75);
+    bool blink(uint8_t times, uint32_t delay_ms = 250);
     void led_on(bool force = false);
     void led_off(bool force = false);
     void poll();

--- a/src/firmware/lib/QuokkADB/include/platform_config.h
+++ b/src/firmware/lib/QuokkADB/include/platform_config.h
@@ -25,7 +25,7 @@
 #pragma once
 
 // Use macros for version number
-#define FW_VER_NUM      "0.2.6"
+#define FW_VER_NUM      "0.3.0"
 #define FW_VER_SUFFIX   "beta"
 #define PLATFORM_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX 
 #define PRODUCT_NAME "QuokkADB"

--- a/src/firmware/lib/QuokkADB/src/blink.cpp
+++ b/src/firmware/lib/QuokkADB/src/blink.cpp
@@ -1,0 +1,117 @@
+//---------------------------------------------------------------------------
+//
+//	QuokkADB ADB keyboard and mouse adapter
+//
+//     Copyright (C) 2023 Rabbit Hole Computing LLC
+//
+//  This file is part of QuokkADB.
+//
+//  This file is free software: you can redistribute it and/or modify it under 
+//  the terms of the GNU General Public License as published by the Free 
+//  Software Foundation, either version 3 of the License, or (at your option) 
+// any later version.
+//
+//  This file is distributed in the hope that it will be useful, but WITHOUT ANY 
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
+//  FOR A PARTICULAR PURPOSE. See the GNU General Public License for more 
+//  details.
+//
+//  You should have received a copy of the GNU General Public License along 
+//  with this file. If not, see <https://www.gnu.org/licenses/>.
+//
+//  Portions of this code were originally released under a Modified BSD 
+//  License. See LICENSE in the root of this repository for more info.
+//
+//----------------------------------------------------------------------------
+#include "blink.h"
+#include "quokkadb_gpio.h"
+#include "adb_platform.h"
+
+BlinkLed blink_led;
+
+bool BlinkLed::blink(uint8_t times, uint32_t delay_ms)
+{
+    blink_event_t* event = new blink_event_t;
+    event->times = times;
+    event->delay_ms = delay_ms;
+    return blink_queue.enqueue(event);
+}
+
+void BlinkLed::led_on(bool force)
+{
+    if (force || !blinking)
+    {
+        LED_ON();
+    }
+}
+
+void BlinkLed::led_off(bool force)
+{
+    if (force || !blinking)
+    {
+        LED_OFF();
+    }
+}
+
+void BlinkLed::poll()
+{
+    static blink_event_t *current_event = nullptr;
+    static bool on_phase = true;
+    static uint8_t blinked = 0;
+    static bool last_delay = false;
+    static uint32_t start_delay;
+
+    if (!blinking && !blink_queue.isEmpty())
+    {
+        current_event = blink_queue.dequeue();
+        start_delay = millis();
+        LED_ON();
+        on_phase = true;
+        blinking = true;
+        blinked = 0;
+        last_delay = false;
+    }
+
+    if (blinking)
+    {
+        if ((uint32_t)(millis() - start_delay) > current_event->delay_ms)
+        {
+            if (last_delay)
+            {
+                if (on_phase)
+                {
+                    // end of blink routine
+                    last_delay = false;
+                    delete current_event;
+                    blinking = false;
+                }
+                else
+                {
+                    // one more delay so there is an extra delay before starting a new blink sequence
+                    start_delay = millis();
+                    on_phase = true;
+                }
+
+            }
+            else if (on_phase)
+            {
+                on_phase = false;
+                LED_OFF();
+                start_delay = millis();
+                if (blinked + 1 >= current_event->times)
+                {
+                    last_delay = true;
+                }
+            }
+            else
+            {
+                blinked++;
+                on_phase = true;
+                LED_ON();
+                start_delay = millis();
+            }
+        }
+    }
+
+    
+}

--- a/src/firmware/lib/QuokkADB/src/quokkadb_gpio.cpp
+++ b/src/firmware/lib/QuokkADB/src/quokkadb_gpio.cpp
@@ -26,14 +26,8 @@
 
 
 #include "quokkadb_gpio.h"
-#include "pico/mutex.h"
 #include "hardware/gpio.h"
 #include <pico/stdio_uart.h>
-#include <pico/printf.h>
-
-mutex_t led_mutex;
-
-
 
 extern bool global_debug;
 void adb_gpio_init(void) {
@@ -48,35 +42,16 @@ void adb_gpio_init(void) {
 
 }
 
-
-
 void led_gpio_init(void) {
     gpio_init(LED_GPIO);
     gpio_set_function(LED_GPIO, GPIO_FUNC_SIO);
     gpio_set_dir(LED_GPIO, GPIO_OUT);
     LED_OFF();
-    mutex_init(&led_mutex);
-
 }
 
 void uart_gpio_init(void) {
 
     uart_init(UART_PORT, UART_TX_BAUD);
     gpio_set_function(UART_TX_GPIO, GPIO_FUNC_UART);
-}
-    
-
-
-// Blink the led n times
-void led_blink(uint8_t times) {
-    mutex_enter_blocking(&led_mutex);
-    for (uint8_t i = 0; i < times; i++) {
-        LED_ON();
-        sleep_ms(75);
-        LED_OFF();
-        sleep_ms(75);
-    }
-    sleep_ms(75);    
-    mutex_exit(&led_mutex);
 }
 

--- a/src/firmware/lib/QuokkADB/src/run_from_sram.ld
+++ b/src/firmware/lib/QuokkADB/src/run_from_sram.ld
@@ -1,0 +1,192 @@
+/** 
+ * ZuluSCSI™ - Copyright (c) 2022 Rabbit Hole Computing™
+ * 
+ * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version. 
+ * 
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ * ----
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version. 
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. 
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**/
+
+MEMORY
+{
+    FLASH(rx) : ORIGIN = 0x10000000, LENGTH = 352k
+    RAM(rwx) : ORIGIN = 0x20000000, LENGTH = 256k  /* Leave space for pico-debug */
+    SCRATCH_X(rwx) : ORIGIN = 0x20040000, LENGTH = 4k
+    SCRATCH_Y(rwx) : ORIGIN = 0x20041000, LENGTH = 4k
+}
+ENTRY(_entry_point)
+SECTIONS
+{
+    .flash_begin : {
+        __flash_binary_start = .;
+    } > FLASH
+    .boot2 : {
+        __boot2_start__ = .;
+        KEEP (*(.boot2))
+        __boot2_end__ = .;
+    } > FLASH
+    ASSERT(__boot2_end__ - __boot2_start__ == 256,
+        "ERROR: Pico second stage bootloader must be 256 bytes in size")
+
+    .text : {
+        __logical_binary_start = .;
+        __real_vectors_start = .;
+        KEEP (*(.vectors))
+        KEEP (*(.binary_info_header))
+        __binary_info_header_end = .;
+        KEEP (*(.reset))
+        KEEP (*(.init))
+        *(.fini)
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+        *(.eh_frame*)
+        . = ALIGN(4);
+
+        /* RP2040 breakpoints in RAM code don't always work very well
+         * because the boot routine tends to overwrite them.
+         * Uncommenting this line puts all code in flash.
+         */
+        /* *(.text .text*) */
+    } > FLASH
+    .rodata : {
+        . = ALIGN(4);
+        *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.flashdata*)))
+        *(.rodata)
+        *(.rodata*)
+        . = ALIGN(4);
+    } > FLASH
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > FLASH
+    __exidx_end = .;
+    . = ALIGN(4);
+    __binary_info_start = .;
+    .binary_info :
+    {
+        KEEP(*(.binary_info.keep.*))
+        *(.binary_info.*)
+    } > FLASH
+    __binary_info_end = .;
+    . = ALIGN(4);
+    __etext = .;
+   .ram_vector_table (COPY): {
+        *(.ram_vector_table)
+    } > RAM
+    .data : {
+        __data_start__ = .;
+        *(vtable)
+
+        /* Time critical code will go here to avoid external flash latency */
+        *(.time_critical*)
+        . = ALIGN(4);
+        *(.text)
+        *(.text*)
+
+        . = ALIGN(4);
+        *(.data*)
+        . = ALIGN(4);
+        *(.after_data.*)
+        . = ALIGN(4);
+        PROVIDE_HIDDEN (__mutex_array_start = .);
+        KEEP(*(SORT(.mutex_array.*)))
+        KEEP(*(.mutex_array))
+        PROVIDE_HIDDEN (__mutex_array_end = .);
+        . = ALIGN(4);
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(SORT(.preinit_array.*)))
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+        . = ALIGN(4);
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+        . = ALIGN(4);
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        *(SORT(.fini_array.*))
+        *(.fini_array)
+        PROVIDE_HIDDEN (__fini_array_end = .);
+        *(.jcr)
+        . = ALIGN(4);
+        __data_end__ = .;
+    } > RAM AT> FLASH
+    .uninitialized_data (COPY): {
+        . = ALIGN(4);
+        *(.uninitialized_data*)
+    } > RAM
+    .scratch_x : {
+        __scratch_x_start__ = .;
+        *(.scratch_x.*)
+        . = ALIGN(4);
+        __scratch_x_end__ = .;
+    } > SCRATCH_X AT > FLASH
+    __scratch_x_source__ = LOADADDR(.scratch_x);
+    .scratch_y : {
+        __scratch_y_start__ = .;
+        *(.scratch_y.*)
+        . = ALIGN(4);
+        __scratch_y_end__ = .;
+    } > SCRATCH_Y AT > FLASH
+    __scratch_y_source__ = LOADADDR(.scratch_y);
+    .bss : {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.bss*)))
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+    .heap (COPY):
+    {
+        __end__ = .;
+        PROVIDE(end = .);
+        *(.heap*)
+        . = ORIGIN(RAM) + LENGTH(RAM) - 0x400;
+        __HeapLimit = .;
+    } > RAM
+    .stack1_dummy (COPY):
+    {
+        *(.stack1*)
+    } > SCRATCH_X
+    .stack_dummy (COPY):
+    {
+        *(.stack*)
+    } > RAM
+    .flash_end : {
+        __flash_binary_end = .;
+    } > FLASH
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackLimit = __StackTop - 0x400;
+    __StackOneTop = ORIGIN(SCRATCH_X) + LENGTH(SCRATCH_X);
+    __StackOneBottom = __StackOneTop - SIZEOF(.stack1_dummy);
+    __StackBottom = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed")
+    ASSERT( __binary_info_header_end - __logical_binary_start <= 256, "Binary info must be in first 256 bytes of the binary")
+}

--- a/src/firmware/lib/QuokkADB/src/usbhost.cpp
+++ b/src/firmware/lib/QuokkADB/src/usbhost.cpp
@@ -34,6 +34,7 @@
 #include "platformmouseparser.h"
 #include "usbmouseparser.h"
 #include "adbkbdparser.h"
+#include "blink.h"
 
 #define kModCmd 1
 #define kModOpt 2
@@ -81,11 +82,11 @@ void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_re
       if(itf_protocol == HID_ITF_PROTOCOL_KEYBOARD) 
       {
         KeyboardPrs.AddKeyboard(dev_addr, instance);
-        led_blink(2);
+        blink_led.blink(2);
       } 
       else // protocol is mouse
       {
-        led_blink(3);
+        blink_led.blink(3);
       }
     }
   }
@@ -95,7 +96,7 @@ void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_re
 void tuh_hid_umount_cb(uint8_t dev_addr, uint8_t instance)
 {
   KeyboardPrs.RemoveKeyboard(dev_addr, instance);
-  led_blink(1);
+  blink_led.blink(1);
 }
 
 // look up new key in previous keys

--- a/src/firmware/platformio.ini
+++ b/src/firmware/platformio.ini
@@ -34,6 +34,7 @@ platform_packages =
 framework = arduino
 board_build.core = earlephilhower
 board = rhc_quokkadb_div4
+board_build.ldscript = lib/QuokkADB/src/run_from_sram.ld
 debug_tool = cmsis-dap
 lib_deps = 
     usb

--- a/src/firmware/platformio.ini
+++ b/src/firmware/platformio.ini
@@ -30,7 +30,7 @@ build_flags =
 [env:quokkadb]
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
 platform_packages =
-    framework-arduinopico@https://github.com/rabbitholecomputing/arduino-pico.git#v3.6.0-usbhost
+    framework-arduinopico@https://github.com/rabbitholecomputing/arduino-pico.git#v3.6.0-tinyusb-0.16.0
 framework = arduino
 board_build.core = earlephilhower
 board = rhc_quokkadb_div4


### PR DESCRIPTION
## Changes
* Updated the TinyUSB library to v0.16.0. This seem to finally fix the occasional bug where USB devices don't get enumerated.
* Using a linker script that put as much code as possible into the SRAM
* The LED status blinking no longer blocks while blinking and the time the LED is on or off has been extended so it is easier to decipher the LED blink status.
