### PR TITLE
Fix right mouse button and QuokkADB freezing

### DIFF
--- a/src/firmware/lib/QuokkADB/include/platform_config.h
+++ b/src/firmware/lib/QuokkADB/include/platform_config.h
@@ -25,7 +25,7 @@
 #pragma once
 
 // Use macros for version number
-#define FW_VER_NUM      "0.5.0"
+#define FW_VER_NUM      "0.5.1"
 #define FW_VER_SUFFIX   "beta"
 #define PLATFORM_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX 
 #define PRODUCT_NAME "QuokkADB"

--- a/src/firmware/lib/QuokkADB/include/platformmouseparser.h
+++ b/src/firmware/lib/QuokkADB/include/platformmouseparser.h
@@ -69,6 +69,11 @@ struct MOUSE_CLICK
         };
 };
 
+enum class MouseRightBtnMode {
+    ctrl_click,
+    right_click
+};
+
 class PlatformMouseParser {
 
         union {
@@ -114,4 +119,6 @@ protected:
         int32_t m_coarse_y = 0;
         int32_t m_fine_x = 0;
         int32_t m_fine_y = 0;
+
+        MouseRightBtnMode m_right_btn_mode = MouseRightBtnMode::ctrl_click;
 };

--- a/src/firmware/lib/usb/include/scqueue.h
+++ b/src/firmware/lib/usb/include/scqueue.h
@@ -31,6 +31,7 @@ namespace simple_circular_queue
     class SCQueue {
         public:
             SCQueue(void);
+            // Queues a pointer, if the queue is full it deletes the pointer
             bool enqueue(T item);
             T dequeue(void);
             T peek(void);

--- a/src/firmware/lib/usb/include/scqueue.tpp
+++ b/src/firmware/lib/usb/include/scqueue.tpp
@@ -38,6 +38,7 @@ namespace simple_circular_queue {
         // no overwriting, return false if queue is full
         if (!is_empty_ && first_ == new_last) {
             enqueued = false;
+            delete item;
         }
         else {
             if(is_empty_) {

--- a/src/firmware/lib/usb/include/usbmouseparser.h
+++ b/src/firmware/lib/usb/include/usbmouseparser.h
@@ -28,11 +28,6 @@
 
 #include "platformmouseparser.h"
 
-enum class MouseRightBtnMode {
-    ctrl_click,
-    right_click
-};
-
 
 class MouseRptParser : public PlatformMouseParser
 {
@@ -60,10 +55,4 @@ private:
     bool m_mouse_left_button_is_pressed = false;
     bool m_mouse_right_button_is_pressed = false;
     bool m_mouse_button_changed = false;
-    #ifdef QUOKKADB
-    MouseRightBtnMode m_right_btn_mode = MouseRightBtnMode::ctrl_click;
-    #else
-    MouseRightBtnMode m_right_btn_mode = MouseRightBtnMode::right_click;
-    #endif
-
 };

--- a/src/firmware/lib/usb/src/usbmouseparser.cpp
+++ b/src/firmware/lib/usb/src/usbmouseparser.cpp
@@ -24,7 +24,6 @@
 
 #include <Arduino.h>
 #include "usbmouseparser.h"
-#include "usb_hid_keys.h"
 #include <platform_logmsg.h>
 
 
@@ -53,12 +52,19 @@ void MouseRptParser::OnLeftButtonUp(MOUSEINFO *mi)
     {
         Logmsg.println("L Bttn Up");
     }
+
  };
 void MouseRptParser::OnLeftButtonDown(MOUSEINFO *mi)
 {
     if (global_debug)
     {
         Logmsg.println("L Bttn Dn");
+    }
+    MOUSE_CLICK* click = new MOUSE_CLICK;
+    click->bmLeftButton = true;
+    if (!m_click_events.enqueue(click))
+    {
+        Logmsg.println("Warning! unable to enqueue Click Down");
     }
 };
 void MouseRptParser::OnRightButtonUp(MOUSEINFO *mi)
@@ -67,49 +73,12 @@ void MouseRptParser::OnRightButtonUp(MOUSEINFO *mi)
     {
         Logmsg.println("R Bttn Up");
     }
-    switch (m_right_btn_mode)
-    {
-        case MouseRightBtnMode::ctrl_click :
-
-            mi->bmLeftButton = false;
-            #ifdef QUOKKADB
-            sleep_ms(100);
-            #else
-            delay(100);
-            #endif
-            while(m_keyboard->PendingKeyboardEvent());
-            m_keyboard->OnKeyUp(0, USB_KEY_LEFTCTRL);
-            while(m_keyboard->PendingKeyboardEvent());
-
-        break;
-        case MouseRightBtnMode::right_click :
-            mi->bmRightButton = false;
-        break;
-    }
-
 };
 void MouseRptParser::OnRightButtonDown(MOUSEINFO *mi)
 {
     if (global_debug)
     {
         Logmsg.println("R Bttn Dn");
-    }
-    switch (m_right_btn_mode)
-    {
-        case MouseRightBtnMode::ctrl_click :
-            while(m_keyboard->PendingKeyboardEvent());
-            m_keyboard->OnKeyDown(0, USB_KEY_LEFTCTRL);
-            while(m_keyboard->PendingKeyboardEvent());
-            #ifdef QUOKKADB
-            sleep_ms(200);
-            #else
-            delay(200);
-            #endif
-            mi->bmLeftButton = true;
-        break;
-        case MouseRightBtnMode::right_click :
-            mi->bmRightButton = true;
-        break;
     }
 };
 void MouseRptParser::OnMiddleButtonUp(MOUSEINFO *mi)
@@ -125,16 +94,6 @@ void MouseRptParser::OnMiddleButtonDown(MOUSEINFO *mi)
     if (global_debug)
     {
         Logmsg.println("M Bttn Dn");
-    }
-    switch (m_right_btn_mode)
-    {
-        case MouseRightBtnMode::ctrl_click :
-            m_right_btn_mode = MouseRightBtnMode::right_click; 
-        break;
-        case MouseRightBtnMode::right_click :
-            m_right_btn_mode = MouseRightBtnMode::ctrl_click;
-        break;
-        
     }
 };
 


### PR DESCRIPTION
The right mouse button wasn't lifting Control after being lifted. The fix for this also seems to fix the QuokkADB freezing after a while. The freezing only occurred in the release build. Under the debug build it worked fine.

A possible memory leak was also addressed in the simple circular queue. Pointers to objects get the `delete` if the queue is full.