### PR TITLE
minor mouse improvements

### DIFF
--- a/src/firmware/lib/QuokkADB/src/platformmouseparser.cpp
+++ b/src/firmware/lib/QuokkADB/src/platformmouseparser.cpp
@@ -57,6 +57,8 @@ int8_t PlatformMouseParser::AdjustMovement(int32_t& axis)
 }
 
 void PlatformMouseParser::Parse(const hid_mouse_report_t *report){
+    auto sensitivity_divisor = setting_storage.settings()->sensitivity_divisor;
+        
     MOUSEINFO mouse_info = {0};
 
     if (m_processed)
@@ -72,6 +74,8 @@ void PlatformMouseParser::Parse(const hid_mouse_report_t *report){
 
     m_x += mouse_info.dX;
     m_y += mouse_info.dY;
+
+    auto significant_motion = (m_x >= sensitivity_divisor || m_x <= -sensitivity_divisor || m_y >= sensitivity_divisor || m_y <= -sensitivity_divisor);
 
     if(mouse_info.dX != 0 || mouse_info.dY != 0) {
         OnMouseMove(&mouse_info);
@@ -198,5 +202,7 @@ void PlatformMouseParser::Parse(const hid_mouse_report_t *report){
         }
     }
     memcpy(prevState.bInfo, &mouse_info, sizeof(prevState.bInfo));
-    m_ready = true;
+    if (significant_motion) {
+        m_ready = true;
+    }
 }

--- a/src/firmware/lib/adb/src/adb.cpp
+++ b/src/firmware/lib/adb/src/adb.cpp
@@ -43,7 +43,6 @@ uint8_t mousepending = 0;
 uint8_t kbdpending = 0;
 uint8_t kbdskip = 0;
 uint16_t kbdprev0 = 0;
-uint16_t mousereg0 = 0;
 uint16_t kbdreg0 = 0;
 uint16_t kbdreg2 = 0xFFFF;
 uint8_t kbdsrq = 0;

--- a/src/firmware/lib/adbuino/src/adbuino.cpp
+++ b/src/firmware/lib/adbuino/src/adbuino.cpp
@@ -56,7 +56,6 @@ extern uint8_t mousepending;
 extern uint8_t kbdpending;
 extern uint8_t kbdskip;
 extern uint16_t kbdprev0;
-extern uint16_t mousereg0;
 extern uint16_t kbdreg0;
 extern uint8_t kbdsrq;
 extern uint8_t mousesrq;
@@ -144,7 +143,6 @@ void loop()
       {
         if (MousePrs.MouseChanged())
         {
-          mousereg0 = MousePrs.GetAdbRegister0();
           mousepending = 1;
         }
       }

--- a/src/firmware/lib/adbuino/src/platformkbdparser.cpp
+++ b/src/firmware/lib/adbuino/src/platformkbdparser.cpp
@@ -153,7 +153,6 @@ extern ADBKbdRptParser KeyboardPrs;
 extern ADBMouseRptParser MousePrs;
 extern uint8_t mousepending;
 extern uint8_t kbdpending;
-extern uint16_t mousereg0;
 extern uint16_t kbdreg0;
 extern uint8_t kbdsrq;
 extern uint8_t mousesrq;

--- a/src/firmware/lib/adbuino/src/ps2kbd.cpp
+++ b/src/firmware/lib/adbuino/src/ps2kbd.cpp
@@ -35,7 +35,6 @@ extern uint8_t mousepending;
 extern uint8_t kbdpending;
 extern uint8_t kbdskip;
 extern uint16_t kbdprev0;
-extern uint16_t mousereg0;
 extern uint16_t kbdreg0;
 extern uint8_t kbdsrq;
 extern uint8_t mousesrq;


### PR DESCRIPTION
This PR removes an unused variable, and with it an extra call to a function that now has side effects. It also suppresses sending mouse reports with no motion, just because the USB moved doesn't mean the ADB needs to. This should reduce bus traffic a little, and maybe makes the mouse a little smoother. It's hard to tell.