### PR TITLE
Fix Ctrl-Command-Power reboot key combo

### DIFF
--- a/.github/disabled_worflows/adbuino_build.yml
+++ b/.github/disabled_worflows/adbuino_build.yml
@@ -11,7 +11,7 @@ jobs:
     
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: adbuino
           fetch-depth: "0"
@@ -34,7 +34,7 @@ jobs:
           utils/rename_adbuino_binaries.sh
 
       - name: Upload binaries into build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: adbuino/src/firmware/distrib/*
           name: ADBuino binaries

--- a/.github/workflows/quokkadb_build.yml
+++ b/.github/workflows/quokkadb_build.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: quokkadb
           fetch-depth: "0"
@@ -36,7 +36,7 @@ jobs:
           utils/rename_quokkadb_binaries.sh
 
       - name: Upload binaries into build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: 
           path: quokkadb/src/firmware/distrib/*
           name: QuokkADB binaries

--- a/src/firmware/lib/QuokkADB/include/platform_config.h
+++ b/src/firmware/lib/QuokkADB/include/platform_config.h
@@ -25,8 +25,8 @@
 #pragma once
 
 // Use macros for version number
-#define FW_VER_NUM      "1.0"
-#define FW_VER_SUFFIX   "release"
+#define FW_VER_NUM      "1.0.1"
+#define FW_VER_SUFFIX   "dev"
 #define PLATFORM_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX 
 #define PRODUCT_NAME "QuokkADB"
 #define PLATFORM_FW_VER_STRING PRODUCT_NAME " firmware: " PLATFORM_FW_VERSION " " __DATE__ " " __TIME__ 

--- a/src/firmware/lib/adb/src/adb.cpp
+++ b/src/firmware/lib/adb/src/adb.cpp
@@ -34,6 +34,7 @@
 #include "math.h"
 #include <platform_logmsg.h>
 #include <adbmouseparser.h>
+#include <adbkbdparser.h>
 
 uint8_t mouse_addr = MOUSE_DEFAULT_ADDR;
 uint8_t kbd_addr = KBD_DEFAULT_ADDR;
@@ -60,6 +61,7 @@ bool kbd_skip_next_listen_reg3 = false;
 bool g_global_reset = false; 
 extern bool global_debug;
 extern ADBMouseRptParser MousePrs;
+extern ADBKbdRptParser KeyboardPrs;
 // The original data_lo code would just set the bit as an output
 // That works for a host, since the host is doing the pullup on the ADB line,
 // but for a device, it won't reliably pull the line low.  We need to actually
@@ -679,7 +681,7 @@ void AdbInterface::ProcessCommand(int16_t cmd)
       {
         Logmsg.println("KBD: Got TALK request for register 2");
       }
-      Send16bitRegister(kbdreg2);
+      Send16bitRegister(KeyboardPrs.GetAdbRegister2());
       break;
     case 0xF: // talk register 3
       kbdreg3 = GetAdbRegister3Keyboard();

--- a/src/firmware/lib/adb/src/adbkbdparser.cpp
+++ b/src/firmware/lib/adb/src/adbkbdparser.cpp
@@ -71,7 +71,7 @@ uint16_t ADBKbdRptParser::GetAdbRegister0()
     if (adb_keycode == ADB_POWER_KEYCODE) {
         if (isKeyUp)
         {
-            B_SET(kbdreg0, ADB_REG_0_KEY_1_STATUS_BIT);
+            B_SET(kbdreg0, ADB_REG_0_KEY_2_STATUS_BIT);
         }
         kbdreg0 |= (adb_keycode << ADB_REG_0_KEY_2_KEY_CODE);
     }

--- a/src/firmware/lib/usb/src/usbkbdparser.cpp
+++ b/src/firmware/lib/usb/src/usbkbdparser.cpp
@@ -125,16 +125,6 @@ void KbdRptParser::OnKeyDown(uint8_t mod, uint8_t key)
     {
         Logmsg.println("Warning! unable to enqueue new KeyDown");
     }
-    // If power button replacement queue key twice
-    else if (key == USB_KEY_PAUSE || key == USB_KEY_F15)
-    {
-        if (!m_keyboard_events.enqueue(new KeyEvent(key, KeyEvent::KeyDown, mod)))
-        {
-            Logmsg.println("Warning! unable to enqueue new Power Button KeyDown");
-        }
-    }
-
-
 
     if (key == USB_KEY_NUMLOCK)
     {
@@ -187,14 +177,6 @@ void KbdRptParser::OnKeyUp(uint8_t mod, uint8_t key)
             Logmsg.println("Warning! unable to enqueue new KeyDown");
         }
     
-        // If power button replacement queue key twice
-        else if (key == USB_KEY_PAUSE || key == USB_KEY_F15)
-        {
-            if (!m_keyboard_events.enqueue(new KeyEvent(key, KeyEvent::KeyUp, mod)))
-            {
-                Logmsg.println("Warning! unable to enqueue new Power Button KeyUp");
-            }
-        }
         if (key == USB_KEY_BACKSPACE)
         {
             B_UNSET(m_custom_mod_keys, DeleteFlag);


### PR DESCRIPTION
After the reboot key combo is held down the Mac OS does a talk reg 2 continuously until the modifier keys are lifted. The talk reg 2 wasn't being updated during that loop so system would start.

Now reg 2 is checked right before it is sent over the ADB bus so the modifier keys are always current.

Another fix was done with the power button. The power key up state was malformed so the power button was stuck down after pressing it. This has been fixed.

Removed code related to double queuing the power button on the USB side. The double queuing is done now on the ADB side. The power button takes up both key press packets so it need to be queued twice and sent on the same talk register 0.