### PR TITLE
Add French keyboard support

### DIFF
--- a/src/firmware/lib/QuokkADB/include/flashsettings.h
+++ b/src/firmware/lib/QuokkADB/include/flashsettings.h
@@ -36,7 +36,8 @@ struct __attribute((packed)) QuokkADBSettings
     uint8_t swap_modifiers: 1;
     uint8_t reserved_bits: 6;
     uint8_t sensitivity_divisor;
-    uint8_t reserved_bytes[252];
+    uint8_t region;
+    uint8_t reserved_bytes[251];
 };
 
 class FlashSettings

--- a/src/firmware/lib/QuokkADB/include/platformkbdparser.h
+++ b/src/firmware/lib/QuokkADB/include/platformkbdparser.h
@@ -34,6 +34,7 @@
 #include <stdint.h>
 #include "tusb.h"
 #include "scqueue.h"
+#include <regions.h>
 
 using simple_circular_queue::SCQueue;
 
@@ -163,7 +164,8 @@ public:
         virtual void OnKeyUp(uint8_t mod __attribute__((unused)), uint8_t key __attribute__((unused))) = 0;
         virtual void OnControlKeysChanged(uint8_t before __attribute__((unused)), uint8_t after __attribute__((unused))) = 0;
 
-
+        virtual Region getRegion(){return region;}
+        virtual void setRegion(Region rgn){region = rgn;}
 protected:
         SCQueue<KeyEvent*, KEYBOARD_QUEUE_CAPACITY> m_keyboard_events; 
         
@@ -209,4 +211,6 @@ protected:
         const uint8_t *getPadKeys() {
                 return padKeys;
         };
+
+        Region region;
 };

--- a/src/firmware/lib/QuokkADB/src/quokkadb.cpp
+++ b/src/firmware/lib/QuokkADB/src/quokkadb.cpp
@@ -88,6 +88,7 @@ void setup()
   blink_led.blink(1);
   adb_gpio_init();
   setting_storage.init();
+  KeyboardPrs.setRegion((Region)setting_storage.settings()->region);
   uart_gpio_init();
   log_init();
   Serial1.begin();

--- a/src/firmware/lib/adb/include/adbkbdparser.h
+++ b/src/firmware/lib/adb/include/adbkbdparser.h
@@ -36,7 +36,7 @@
 
 using simple_circular_queue::SCQueue;
 
-extern uint8_t usb_keycode_to_adb_code(uint8_t usb_code);
+extern uint8_t usb_keycode_to_adb_code(uint8_t usb_code, Region region);
 
 
 class ADBKbdRptParser : public KbdRptParser

--- a/src/firmware/lib/adb/src/adbkbdparser.cpp
+++ b/src/firmware/lib/adb/src/adbkbdparser.cpp
@@ -59,7 +59,7 @@ uint16_t ADBKbdRptParser::GetAdbRegister0()
         {
             B_SET(kbdreg0, ADB_REG_0_KEY_1_STATUS_BIT);
         }
-        adb_keycode = usb_keycode_to_adb_code(event->GetKeycode());
+        adb_keycode = usb_keycode_to_adb_code(event->GetKeycode(), getRegion());
         kbdreg0 |= (adb_keycode << ADB_REG_0_KEY_1_KEY_CODE);
         delete(event);
     }
@@ -80,14 +80,14 @@ uint16_t ADBKbdRptParser::GetAdbRegister0()
             event = m_keyboard_events.peek();
             // if the first key wasn't the power key but the second one is, skip the second key packing
             // so on the next cycle the power key will be packed as both the first and second key
-            if (event != NULL && usb_keycode_to_adb_code(event->GetKeycode()) != ADB_POWER_KEYCODE)
+            if (event != NULL && usb_keycode_to_adb_code(event->GetKeycode(), getRegion()) != ADB_POWER_KEYCODE)
             {
                 event = m_keyboard_events.dequeue();
                 if (event->IsKeyUp())
                 {
                     B_SET(kbdreg0, ADB_REG_0_KEY_2_STATUS_BIT); 
                 }
-                adb_keycode = usb_keycode_to_adb_code(event->GetKeycode());
+                adb_keycode = usb_keycode_to_adb_code(event->GetKeycode(), getRegion());
                 kbdreg0 |= (adb_keycode << ADB_REG_0_KEY_2_KEY_CODE);
                 free(event);
             }

--- a/src/firmware/lib/adb/src/usbtoadb.cpp
+++ b/src/firmware/lib/adb/src/usbtoadb.cpp
@@ -30,6 +30,8 @@
 #include "usb_hid_keys.h"
 #include <stdint.h>
 #include <Arduino.h>
+#include <regions.h>
+
 // #ifdef ADBUINO
 // #include <Arduino.h>
 #ifdef QUOKKADB
@@ -44,7 +46,7 @@ extern bool global_debug;
 
 // Virtual Keycodes for the Mac QWERTY Layout
 // Keycodes are in hexadecimal.
-uint8_t usb_keycode_to_adb_code(uint8_t usb_code)
+uint8_t usb_keycode_to_adb_code(uint8_t usb_code, Region region)
 {
     switch (usb_code)
     {
@@ -130,6 +132,12 @@ uint8_t usb_keycode_to_adb_code(uint8_t usb_code)
         return 0x28;
     case USB_KEY_SEMICOLON:
         return 0x29;
+    case USB_KEY_HASHTILDE:
+        // for now just fall through to Backslash
+        // if (region == RegionFR)
+        //     return 0x2A;
+        // else
+        //     return 0x2A;
     case USB_KEY_BACKSLASH:
         return 0x2A;
     case USB_KEY_COMMA:
@@ -146,8 +154,16 @@ uint8_t usb_keycode_to_adb_code(uint8_t usb_code)
         return 0x30;
     case USB_KEY_SPACE:
         return 0x31;
+    case  USB_KEY_102ND:
+        if (region == RegionFR)
+            return 0x32;
+        else
+            return 0x32; // current default is France for this ISO key
     case USB_KEY_GRAVE:
-        return 0x32;
+        if (region == RegionFR)
+            return 0xA0;
+        else
+            return 0x32; // RegionUS
     case USB_KEY_BACKSPACE:
         return 0x33;
     case USB_KEY_ESC:

--- a/src/firmware/lib/adbuino/src/platformkbdparser.cpp
+++ b/src/firmware/lib/adbuino/src/platformkbdparser.cpp
@@ -131,7 +131,7 @@ void PlatformKbdParser::SendString(const char * message)
 
         while(message[i] != '\0')        
         {
-                key = char_to_usb_keycode(message[i++]);
+                key = char_to_usb_keycode(message[i++], region);
 
                 if (key.shift_down) {
                         OnKeyDown(0, USB_KEY_LEFTSHIFT);

--- a/src/firmware/lib/misc/include/regions.h
+++ b/src/firmware/lib/misc/include/regions.h
@@ -1,16 +1,15 @@
 //---------------------------------------------------------------------------
 //
-//	ADBuino & QuokkADB ADB keyboard and mouse adapter
-
-//	   Copyright (C) 2021-2022 akuker
-//     Copyright (C) 2022 Rabbit Hole Computing LLC
+//	QuokkADB ADB keyboard and mouse adapter
 //
-//  This file is part of the ADBuino and the QuokkADB projects.
+//     Copyright (C) 2024 Rabbit Hole Computing LLC
+//
+//  This file is part of QuokkADB.
 //
 //  This file is free software: you can redistribute it and/or modify it under 
 //  the terms of the GNU General Public License as published by the Free 
 //  Software Foundation, either version 3 of the License, or (at your option) 
-//  any later version.
+// any later version.
 //
 //  This file is distributed in the hope that it will be useful, but WITHOUT ANY 
 //  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
@@ -18,19 +17,19 @@
 //  details.
 //
 //  You should have received a copy of the GNU General Public License along 
-//  with the file. If not, see <https://www.gnu.org/licenses/>.
+//  with this file. If not, see <https://www.gnu.org/licenses/>.
+//
+//  Portions of this code were originally released under a Modified BSD 
+//  License. See LICENSE in the root of this repository for more info.
 //
 //----------------------------------------------------------------------------
-#pragma once
 
-#include <stdint.h>
-#include <regions.h>
+#pragma once 
 
-struct usbkey_t
+#define LAST_REGION RegionFR
+enum Region
 {
-    uint8_t keycode;
-    bool shift_down;
+        RegionUS = 0,
+        RegionFR
 };
 
-
-usbkey_t char_to_usb_keycode(char character, Region region);

--- a/src/firmware/lib/usb/src/char2usbkeycode.cpp
+++ b/src/firmware/lib/usb/src/char2usbkeycode.cpp
@@ -24,49 +24,99 @@
 
 #include "usb_hid_keys.h"
 #include "char2usbkeycode.h"
+#include <ctype.h>
+static uint8_t alpha_azerty_usb_keycode(const char letter)
+{
+    switch (tolower(letter))
+    {
+        case 'a': return USB_KEY_Q;
+        case 'z': return USB_KEY_W;
+        case 'q': return USB_KEY_A;
+        case 'm': return USB_KEY_SEMICOLON;
+        case 'w': return USB_KEY_Z;
+        default: // do nothing
+            break;
+    }
 
-usbkey_t char_to_usb_keycode(char character)
+    return USB_KEY_A + tolower(letter) - 'a';
+}
+
+usbkey_t char_to_usb_keycode(char character, Region region)
 {
     usbkey_t key;
     if (character >= 'A' && character <= 'Z')
     {
-        key.keycode = USB_KEY_A + (character - 'A');
+        if (region == RegionUS)
+        {
+            key.keycode = USB_KEY_A + (character - 'A');
+        }
+        if (region == RegionFR)
+        {
+            key.keycode = alpha_azerty_usb_keycode(character);
+        }
         key.shift_down = true;
         return key;
     }
 
     if (character >= 'a' && character <= 'z')
     {
-        key.keycode = USB_KEY_A + (character - 'a');
+        if (region == RegionUS)
+            key.keycode = USB_KEY_A + (character - 'a');
+        if (region == RegionFR)
+            key.keycode = alpha_azerty_usb_keycode(character);
+
         key.shift_down = false;
         return key;
     }
 
     if (character == '.')
     {
-        key.keycode = USB_KEY_DOT;
-        key.shift_down = false;
+        if (region == RegionUS)
+        {
+            key.keycode = USB_KEY_DOT;
+            key.shift_down = false;
+        }
+        if (region == RegionFR)
+        {
+            key.keycode = USB_KEY_COMMA;
+            key.shift_down = false;
+        }
         return key;
     }
 
     if (character == '0')
     {
         key.keycode = USB_KEY_0;
-        key.shift_down = false;
+        if (region == RegionUS)
+            key.shift_down = false;
+        if (region == RegionFR)
+            key.shift_down = true;
+
         return key;
     }
 
     if (character >= '1' && character <= '9')
     {
         key.keycode = USB_KEY_1 + (character - '1');
-        key.shift_down = false;
+        if (region == RegionUS)
+            key.shift_down = false;
+        if (region == RegionFR)
+            key.shift_down = true;
         return key;
     }
 
     if (character == ':')
     {
-        key.keycode = USB_KEY_SEMICOLON;
-        key.shift_down = true;
+        if (region == RegionUS)
+        {
+            key.keycode = USB_KEY_SEMICOLON;
+            key.shift_down = true;
+        }
+        if (region == RegionFR)
+        {
+            key.keycode = USB_KEY_DOT;
+            key.shift_down = false;
+        }
         return key;
     }
 
@@ -79,8 +129,21 @@ usbkey_t char_to_usb_keycode(char character)
 
     if (character == '-')
     {
-        key.keycode = USB_KEY_MINUS;
+        if (region == RegionUS)
+            key.keycode = USB_KEY_MINUS;
+        if (region == RegionFR)
+            key.keycode = USB_KEY_EQUAL;
         key.shift_down = false;
+        return key;
+    }
+
+    if (character == '*')
+    {
+        if (region == RegionUS)
+            key.keycode = USB_KEY_8;
+        if (region == RegionFR)
+            key.keycode = USB_KEY_RIGHTBRACE;
+        key.shift_down = true;
         return key;
     }
 
@@ -93,69 +156,117 @@ usbkey_t char_to_usb_keycode(char character)
 
     if (character == '[')
     {
-        key.keycode = USB_KEY_LEFTBRACE;
+        if (region == RegionUS)
+            key.keycode = USB_KEY_LEFTBRACE;
+        if (region == RegionFR)
+            key.keycode = USB_KEY_102ND;
         key.shift_down = false;
         return key;
     }
 
     if (character == ']')
     {
-        key.keycode = USB_KEY_RIGHTBRACE;
-        key.shift_down = false;
+        if (region == RegionUS)
+        {
+            key.keycode = USB_KEY_RIGHTBRACE;
+            key.shift_down = false;
+        }
+        if (region == RegionFR)
+        {
+            key.keycode = USB_KEY_102ND;
+            key.shift_down = true;
+        }
         return key;
     }
 
     if (character == '=')
     {
-        key.keycode = USB_KEY_EQUAL;
+        if (region == RegionUS)
+            key.keycode = USB_KEY_EQUAL;
+        if (region == RegionFR)
+            key.keycode = USB_KEY_SLASH;
         key.shift_down = false;
         return key;
     }
 
     if (character == '+')
     {
-        key.keycode = USB_KEY_EQUAL;
+        if (region == RegionUS)
+            key.keycode = USB_KEY_EQUAL;
+        if (region == RegionFR)
+            key.keycode = USB_KEY_SLASH;
         key.shift_down = true;
         return key;
     }
 
     if (character == '(')
     {
-        key.keycode = USB_KEY_9;
-        key.shift_down = true;
+        if (region == RegionUS)
+        {
+            key.keycode = USB_KEY_9;
+            key.shift_down = true;
+        }
+        if (region == RegionFR)
+        {
+            key.keycode = USB_KEY_5;
+            key.shift_down = false;
+        }
         return key;
     }
 
     if (character == ')')
     {
-        key.keycode = USB_KEY_0;
-        key.shift_down = true;
+        if (region == RegionUS)
+        {
+            key.keycode = USB_KEY_0;
+            key.shift_down = true;
+        }
+        if (region == RegionFR)
+        {
+            key.keycode = USB_KEY_MINUS;
+            key.shift_down = false;
+        }
+
         return key;
     }
 
     if (character == '/')
     {
-        key.keycode = USB_KEY_SLASH;
-        key.shift_down = false;
+        if (region == RegionUS)
+        {
+            key.keycode = USB_KEY_SLASH;
+            key.shift_down = false;
+        }
+        if (region == RegionFR)
+        {
+            key.keycode = USB_KEY_DOT;
+            key.shift_down = true;
+        }
         return key;
     }
 
     if (character == '<')
     {
-        key.keycode = USB_KEY_COMMA;
-        key.shift_down = true;
+        if (region == RegionUS)
+        {
+            key.keycode = USB_KEY_COMMA;
+            key.shift_down = true;
+        }
+        if (region == RegionFR)
+        {
+            key.keycode = USB_KEY_102ND;
+            key.shift_down = false;
+        }
         return key;
     }
 
-    if (character == '<')
-    {
-        key.keycode = USB_KEY_COMMA;
-        key.shift_down = true;
-        return key;
-    }
     if (character == '>')
     {
-        key.keycode = USB_KEY_DOT;
+        if (region == RegionUS)
+            key.keycode = USB_KEY_DOT;
+        if (region == RegionFR)
+            key.keycode = USB_KEY_102ND;
+
         key.shift_down = true;
         return key;
     }


### PR DESCRIPTION
Switched key codes based on a new region setting.
Properly encoded the ghost typing of the QuokkADB settings when the region is set to France.